### PR TITLE
swap m_customGlowColor and m_glowColorIsLBG members

### DIFF
--- a/src/decomp/PlayLayer.cpp
+++ b/src/decomp/PlayLayer.cpp
@@ -168,8 +168,8 @@ void decomp_PlayLayer::virtual_updateVisibility(float delta) {
             }
         }
 
-        if (object->m_glowColorIsLBG) {
-            if (!object->m_customGlowColor)
+        if (object->m_customGlowColor) {
+            if (!object->m_glowColorIsLBG)
                 object->setGlowColor(m_lightBGColor);
             else
                 object->setGlowColor(colorLBG);


### PR DESCRIPTION
this pr swaps the `GameObject::m_customGlowColor` and `GameObject::m_glowColorIsLBG` members. see geode-sdk/bindings#1293 for more info, but in short a few months ago these members were incorrectly swapped without my knowledge, so i recently reverted them back.

`m_glowColorIsLBG` is also used in `ObjectUtils.hpp`, however i didn't swap it since it seems correct as is.

pinged you in the geode server but i guess you missed it so i'm just making this a pr :)